### PR TITLE
Add an option to skip responses in result file

### DIFF
--- a/src/playwright-har-config.ts
+++ b/src/playwright-har-config.ts
@@ -1,0 +1,3 @@
+export class PlaywrightHarConfig {
+    public recordResponses: boolean = true;
+}

--- a/src/playwright-har.ts
+++ b/src/playwright-har.ts
@@ -9,7 +9,7 @@ export class PlaywrightHar {
     private client: CDPSession;
     private addResponseBodyPromises = [];
     private events = [];
-    private config = [];
+    private config: PlaywrightHarConfig;
 
     constructor(page: Page, config: PlaywrightHarConfig = null) {
         this.page = page;

--- a/src/playwright-har.ts
+++ b/src/playwright-har.ts
@@ -1,6 +1,7 @@
 import { harFromMessages } from 'chrome-har';
 import { writeFileSync } from 'fs';
 import { CDPSession, Page } from 'playwright-chromium';
+import { PlaywrightHarConfig } from 'playwright-har-config';
 
 export class PlaywrightHar {
 
@@ -8,9 +9,14 @@ export class PlaywrightHar {
     private client: CDPSession;
     private addResponseBodyPromises = [];
     private events = [];
+    private config = [];
 
-    constructor(page: Page) {
+    constructor(page: Page, config: PlaywrightHarConfig = null) {
         this.page = page;
+
+        if (config == null) {
+          this.config = new PlaywrightHarConfig();
+        }
     }
 
     async start() {
@@ -41,6 +47,10 @@ export class PlaywrightHar {
                 const harEvent = { method, params };
                 this.events.push(harEvent);
                 if (method === 'Network.responseReceived') {
+                    if (this.config.recordResponses === false) {
+                        return;
+                    }
+                    
                     const response = harEvent.params.response;
                     const requestId = harEvent.params.requestId;
                     // Response body is unavailable for redirects, no-content, image, audio and video responses
@@ -70,7 +80,7 @@ export class PlaywrightHar {
 
     async stop(path?: string) {
         await Promise.all(this.addResponseBodyPromises);
-        const harObject = harFromMessages(this.events, { includeTextFromResponseBody: true });
+        const harObject = harFromMessages(this.events, { includeTextFromResponseBody: this.config.recordResponses !== false });
         this.events = [];
         this.addResponseBodyPromises = [];
         if (path) {


### PR DESCRIPTION
Thank you for a great library! It saved me a lot of time and effort.

I used the library in the converting chain of: playwright -> HAR -> [LI-HAR](https://github.com/grafana/har-to-k6/blob/master/li-har.spec.md) -> k6 script; And noticed that result file could be much smaller without response part.

So, I suggest adding a config with a flag to omit responses. This new flag is disabled by default to keep backward compatibility.